### PR TITLE
fix: macos vs windows dot on Eindhoven

### DIFF
--- a/src/EindhovenLogo.jl
+++ b/src/EindhovenLogo.jl
@@ -68,7 +68,13 @@ function draw_eindhoven(;scale::Real=4.5, textcolor="black")
     fillpreserve()
     #settext("eindhoven", Point(xoffset-215*scale, 110*scale))
     sethue(Luxor.julia_blue...)
-    circle(-45*scale, -7.5*scale, 2.5*scale, :fill)
+    if Sys.isapple()
+        circle(-60*scale, -7.5*scale, 2.5*scale, :fill)
+    else
+        circle(-45*scale, -7.5*scale, 2.5*scale, :fill)
+    end
+    
+    
 end
 
 # copy-pasted from Luxor.jl and added scale, sorry


### PR DESCRIPTION
Addresses #8 where on macOS the dot on Eindhoven is in the wrong place. Simple little fix.